### PR TITLE
Add preprediction of UPOS tags

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,3 +48,6 @@ source activate testenv
 echo "Installing requirements"
 pip install --upgrade pip --quiet
 pip install -r requirements.txt --quiet
+
+# Install StanfordNLP models
+python -c "import stanfordnlp; stanfordnlp.download('en', force=True)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 git+git://github.com/allenai/allennlp.git@770791a2045d960beaf4e64db867f51e6021afb6
+stanfordnlp
+
 # Run tests
 pytest
 

--- a/streusle_tagger/dataset_readers/streusle.py
+++ b/streusle_tagger/dataset_readers/streusle.py
@@ -102,6 +102,8 @@ class StreusleDatasetReader(DatasetReader):
                                                             tokenize_pretokenized=True)
                 doc = self._upos_predictor([tokens])
                 upos_tags = [word.upos for sent in doc.sentences for word in sent.words]
+        # Check number of UPOS tags equals number of tokens.
+        assert len(upos_tags) == len(tokens)
         metadata["upos_tags"] = upos_tags
 
         fields["metadata"] = MetadataField(metadata)

--- a/streusle_tagger/dataset_readers/streusle.py
+++ b/streusle_tagger/dataset_readers/streusle.py
@@ -98,10 +98,11 @@ class StreusleDatasetReader(DatasetReader):
         metadata = {"tokens": tokens}
         if self._use_predicted_upos or upos_tags is None:
             if self._upos_predictor is None:
+                # Initialize UPOS predictor.
                 self._upos_predictor = stanfordnlp.Pipeline(processors="tokenize,pos",
                                                             tokenize_pretokenized=True)
-                doc = self._upos_predictor([tokens])
-                upos_tags = [word.upos for sent in doc.sentences for word in sent.words]
+            doc = self._upos_predictor([tokens])
+            upos_tags = [word.upos for sent in doc.sentences for word in sent.words]
         # Check number of UPOS tags equals number of tokens.
         assert len(upos_tags) == len(tokens)
         metadata["upos_tags"] = upos_tags

--- a/streusle_tagger/predictors/streusle_tagger.py
+++ b/streusle_tagger/predictors/streusle_tagger.py
@@ -12,7 +12,9 @@ class StreusleTaggerPredictor(Predictor):
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         """
-        Expects JSON that looks like ``{"tokens": "[..., ..., ...]"}``.
+        Expects JSON that looks like ``{"tokens": "[...]", "upos_tags": "[...]"}``.
         """
         tokens = json_dict["tokens"]
-        return self._dataset_reader.text_to_instance(tokens)
+        upos_tags = json_dict.get("upos_tags", None)
+        return self._dataset_reader.text_to_instance(tokens=tokens,
+                                                     upos_tags=upos_tags)

--- a/tests/dataset_readers/streusle_test.py
+++ b/tests/dataset_readers/streusle_test.py
@@ -10,13 +10,17 @@ class TestStreusleDatasetReader():
     @pytest.mark.parametrize('lazy', (True, False))
     def test_read_from_file(self, lazy):
         reader = StreusleDatasetReader(lazy=lazy)
+        assert reader._upos_predictor is None
         instances = ensure_list(reader.read(str('fixtures/data/streusle.json')))
+        assert reader._upos_predictor is None
         assert len(instances) == 3
 
         instance = instances[0]
         fields = instance.fields
         assert [token.text for token in fields["tokens"]] == [
                 'Have', 'a', 'real', 'mechanic', 'check', 'before', 'you', 'buy', '!!!!']
+        assert fields["metadata"]["upos_tags"] == [
+                'VERB', 'DET', 'ADJ', 'NOUN', 'VERB', 'SCONJ', 'PRON', 'VERB', 'PUNCT']
         assert fields["tags"].labels == ["B-V-v.social", "o-DET", "o-ADJ",
                                          "o-N-n.PERSON", "I~-V-v.cognition",
                                          "O-P-p.Time", "O-PRON", "O-V-v.possession",
@@ -26,6 +30,8 @@ class TestStreusleDatasetReader():
         fields = instance.fields
         assert [token.text for token in fields["tokens"]] == [
                 "Very", "good", "with", "my", "5", "year", "old", "daughter", "."]
+        assert fields["metadata"]["upos_tags"] == [
+                'ADV', 'ADJ', 'ADP', 'PRON', 'NUM', 'NOUN', 'ADJ', 'NOUN', 'PUNCT']
         assert fields["tags"].labels == ["O-ADV", "O-ADJ", "O-P-??",
                                          "O-PRON.POSS-p.SocialRel|p.Gestalt", "O-NUM",
                                          "B-N-n.PERSON", "I_", "O-N-n.PERSON", "O-PUNCT"]
@@ -36,6 +42,58 @@ class TestStreusleDatasetReader():
                 'After', 'firing', 'this', 'company', 'my', 'next', 'pool',
                 'service', 'found', 'the', 'filters', 'had', 'not', 'been',
                 'cleaned', 'as', 'they', 'should', 'have', 'been', '.']
+        assert fields["metadata"]["upos_tags"] == [
+                'SCONJ', 'VERB', 'DET', 'NOUN', 'PRON', 'ADJ', 'NOUN', 'NOUN', 'VERB',
+                'DET', 'NOUN', 'AUX', 'PART', 'AUX', 'VERB', 'SCONJ', 'PRON', 'AUX',
+                'AUX', 'AUX', 'PUNCT']
+        assert fields["tags"].labels == ["O-P-p.Time", "O-V-v.social", "O-DET",
+                                         "O-N-n.GROUP", "O-PRON.POSS-p.OrgRole|p.Gestalt",
+                                         "O-ADJ", "B-N-n.ACT", "I_", "O-V-v.cognition",
+                                         "O-DET", "O-N-n.ARTIFACT", "O-AUX", "O-ADV",
+                                         "O-AUX", "O-V-v.change",
+                                         "O-P-p.ComparisonRef", "O-PRON", "O-AUX",
+                                         "O-AUX", "O-AUX", "O-PUNCT"]
+
+    @pytest.mark.parametrize('lazy', (True, False))
+    def test_read_from_file_predicted_upos(self, lazy):
+        reader = StreusleDatasetReader(use_predicted_upos=True,
+                                       lazy=lazy)
+        assert reader._upos_predictor is None
+        instances = ensure_list(reader.read(str('fixtures/data/streusle.json')))
+        assert reader._upos_predictor is not None
+        assert len(instances) == 3
+
+        instance = instances[0]
+        fields = instance.fields
+        assert [token.text for token in fields["tokens"]] == [
+                'Have', 'a', 'real', 'mechanic', 'check', 'before', 'you', 'buy', '!!!!']
+        assert fields["metadata"]["upos_tags"] == [
+                'VERB', 'DET', 'ADJ', 'ADJ', 'NOUN', 'SCONJ', 'PRON', 'VERB', 'PUNCT']
+        assert fields["tags"].labels == ["B-V-v.social", "o-DET", "o-ADJ",
+                                         "o-N-n.PERSON", "I~-V-v.cognition",
+                                         "O-P-p.Time", "O-PRON", "O-V-v.possession",
+                                         "O-PUNCT"]
+
+        instance = instances[1]
+        fields = instance.fields
+        assert [token.text for token in fields["tokens"]] == [
+                "Very", "good", "with", "my", "5", "year", "old", "daughter", "."]
+        assert fields["metadata"]["upos_tags"] == [
+                'ADV', 'ADJ', 'ADP', 'PRON', 'NUM', 'NOUN', 'ADJ', 'NOUN', 'PUNCT']
+        assert fields["tags"].labels == ["O-ADV", "O-ADJ", "O-P-??",
+                                         "O-PRON.POSS-p.SocialRel|p.Gestalt", "O-NUM",
+                                         "B-N-n.PERSON", "I_", "O-N-n.PERSON", "O-PUNCT"]
+
+        instance = instances[2]
+        fields = instance.fields
+        assert [token.text for token in fields["tokens"]] == [
+                'After', 'firing', 'this', 'company', 'my', 'next', 'pool',
+                'service', 'found', 'the', 'filters', 'had', 'not', 'been',
+                'cleaned', 'as', 'they', 'should', 'have', 'been', '.']
+        assert fields["metadata"]["upos_tags"] == [
+            'SCONJ', 'VERB', 'DET', 'NOUN', 'PRON', 'ADJ', 'NOUN', 'NOUN', 'VERB',
+            'DET', 'NOUN', 'AUX', 'PART', 'AUX', 'VERB', 'SCONJ', 'PRON', 'AUX',
+            'AUX', 'AUX', 'PUNCT']
         assert fields["tags"].labels == ["O-P-p.Time", "O-V-v.social", "O-DET",
                                          "O-N-n.GROUP", "O-PRON.POSS-p.OrgRole|p.Gestalt",
                                          "O-ADJ", "B-N-n.ACT", "I_", "O-V-v.cognition",


### PR DESCRIPTION
to-do:

- [x] predict UPOS as preprocessing step
- [ ] generate constraints based on UPOS predictions (for future PR)
- [ ] do STREUSLE tagging with the generated constraints, which might differ between instances. (for future PR)

This PR adds prediction of UPOS tags, courtesy of stanfordnlp. It might be a bit slow, since the pos tagging isn't batched, but luckily we only have to do this once when loading the dataset (so it seems like premature optimization to try speeding it up now...)