### PR TITLE
Edit output format, include more information

### DIFF
--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -202,7 +202,7 @@ class StreusleTagger(Model):
         # Just get the tags and ignore the score.
         predicted_tags = [x for x, y in best_paths]
 
-        output = {"constrained_logits": constrained_logits, "mask": mask, "tags": predicted_tags}
+        output = {"constrained_logits": constrained_logits, "mask": mask, "tags": predicted_tags, "upos_tags": batch_upos_tags}
 
         if tags is not None:
             # Add negative log-likelihood as loss

--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -202,7 +202,13 @@ class StreusleTagger(Model):
         # Just get the tags and ignore the score.
         predicted_tags = [x for x, y in best_paths]
 
-        output = {"constrained_logits": constrained_logits, "mask": mask, "tags": predicted_tags, "upos_tags": batch_upos_tags}
+        output = {
+                "constrained_logits": constrained_logits,
+                "mask": mask,
+                "tags": predicted_tags,
+                "upos_tags": batch_upos_tags,
+                "tokens": [instance_metadata["tokens"] for instance_metadata in metadata]
+        }
 
         if tags is not None:
             # Add negative log-likelihood as loss

--- a/streusle_tagger/predictors/streusle_tagger.py
+++ b/streusle_tagger/predictors/streusle_tagger.py
@@ -18,9 +18,3 @@ class StreusleTaggerPredictor(Predictor):
         upos_tags = json_dict.get("upos_tags", None)
         return self._dataset_reader.text_to_instance(tokens=tokens,
                                                      upos_tags=upos_tags)
-
-    def dump_line(self, outputs: JsonDict) -> str:
-        if "mask" in outputs:
-            return str(outputs["tags"][:sum(outputs["mask"])]) + "\n"
-        else:
-            return str(outputs["tags"]) + "\n"


### PR DESCRIPTION
This PR modifies the prediction output files to be jsonl files with a variety of fields, most importantly:

- `tags` (the predicted tags)
- `tokens` (the original tokens)
- `upos_tags` (the predicted UPOS tags)