### PR TITLE
Fix constraining logits by masking with large neg. #, vs. 0

### DIFF
--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -267,10 +267,10 @@ class StreusleTagger(Model):
         """
         # TODO(nfliu): this is pretty inefficient, maybe there's someway to make it batched?
         # Shape: (batch_size, max_sequence_length, num_tags)
-        upos_constraint_mask = torch.zeros(len(batch_upos_tags),
-                                           len(max(batch_upos_tags, key=len)),
-                                           self.num_tags,
-                                           device=next(self.tag_projection_layer.parameters()).device)
+        upos_constraint_mask = torch.ones(len(batch_upos_tags),
+                                          len(max(batch_upos_tags, key=len)),
+                                          self.num_tags,
+                                          device=next(self.tag_projection_layer.parameters()).device) * -1e80
         # Iterate over the batch
         for example_index, example_upos_tags in enumerate(
                 batch_upos_tags):

--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -270,7 +270,7 @@ class StreusleTagger(Model):
         upos_constraint_mask = torch.ones(len(batch_upos_tags),
                                           len(max(batch_upos_tags, key=len)),
                                           self.num_tags,
-                                          device=next(self.tag_projection_layer.parameters()).device) * -1e80
+                                          device=next(self.tag_projection_layer.parameters()).device) * -1e32
         # Iterate over the batch
         for example_index, example_upos_tags in enumerate(
                 batch_upos_tags):

--- a/training_config/streusle_bert_large_cased.jsonnet
+++ b/training_config/streusle_bert_large_cased.jsonnet
@@ -37,7 +37,7 @@
         "type": "adam",
         "lr": 0.001
     },
-    "num_serialized_models_to_keep": 3,
+    "num_serialized_models_to_keep": 1,
     "num_epochs": 75,
     "grad_norm": 5.0,
     "patience": 25,


### PR DESCRIPTION
Said large negative number is `-1e80`