### PR TITLE
Restructure as multitask learning over independent output spaces

### DIFF
--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -118,8 +118,9 @@ class StreusleTagger(Model):
             self._upos_to_label_mask: Dict[str, torch.Tensor] = {}
             for upos in ALL_UPOS:
                 # Shape: (num_labels,)
-                upos_label_mask = torch.zeros(len(mwe_lexcat_tags),
-                                              device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device)
+                upos_label_mask = torch.zeros(
+                        len(mwe_lexcat_tags),
+                        device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device)
                 # Go through the labels and indices and fill in the values that are allowed.
                 for label_index, label in mwe_lexcat_tags.items():
                     if len(label.split("-")) == 1:
@@ -147,8 +148,9 @@ class StreusleTagger(Model):
                     if upos_tag not in self._lemma_to_allowed_lexcats[lemma]:
                         continue
                     # Shape: (num_labels,)
-                    lemma_upos_label_mask = torch.zeros(len(mwe_lexcat_tags),
-                                                        device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device)
+                    lemma_upos_label_mask = torch.zeros(
+                            len(mwe_lexcat_tags),
+                            device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device)
                     # Go through the labels and indices and fill in the values that are allowed.
                     for label_index, label in mwe_lexcat_tags.items():
                         # For ~i, etc. tags. We don't deal with them here.
@@ -436,10 +438,11 @@ class StreusleTagger(Model):
         """
         # TODO(nfliu): this is pretty inefficient, maybe there's someway to make it batched?
         # Shape: (batch_size, max_sequence_length, num_tags)
-        upos_constraint_mask = torch.ones(len(batch_upos_tags),
-                                          len(max(batch_upos_tags, key=len)),
-                                          self.num_mwe_lexcat_tags,
-                                          device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device) * -1e32
+        upos_constraint_mask = torch.ones(
+                len(batch_upos_tags),
+                len(max(batch_upos_tags, key=len)),
+                self.num_mwe_lexcat_tags,
+                device=next(self.mwe_lexcat_tag_projection_layer.parameters()).device) * -1e32
         # Iterate over the batch
         for example_index, (example_upos_tags, example_lemmas) in enumerate(
                 zip(batch_upos_tags, batch_lemmas)):

--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -403,7 +403,7 @@ class StreusleTagger(Model):
                         lextag = f"{lextag}|{ss2_tag}"
                 lextags.append(lextag)
             all_lextags.append(lextags)
-        output_dict["lextags"] = all_lextags
+        output_dict["tags"] = all_lextags
         return output_dict
 
     @overrides

--- a/streusle_tagger/models/streusle_tagger.py
+++ b/streusle_tagger/models/streusle_tagger.py
@@ -368,6 +368,25 @@ class StreusleTagger(Model):
             ss2_tags = ss2_tags[:mask.sum()]
             all_ss2_tags.append(ss2_tags)
         output_dict["ss2_tags"] = all_ss2_tags
+        # Construct the lextags from the predicted "mwe_lexcat_tags", "ss2_tags", and "ss_tags"
+        all_lextags = []
+        assert len(output_dict["mwe_lexcat_tags"]) == len(output_dict["ss_tags"])
+        assert len(output_dict["ss_tags"]) == len(output_dict["ss2_tags"])
+        for mwe_lexcat_tags, ss_tags, ss2_tags in zip(output_dict["mwe_lexcat_tags"],
+                                                      output_dict["ss_tags"],
+                                                      output_dict["ss2_tags"]):
+            lextags = []
+            assert len(mwe_lexcat_tags) == len(ss_tags)
+            assert len(ss_tags) == len(ss2_tags)
+            for mwe_lexcat_tag, ss_tag, ss2_tag in zip(mwe_lexcat_tags, ss_tags, ss2_tags):
+                lextag = mwe_lexcat_tag
+                if ss_tag != "@@<NO_SS>@@":
+                    lextag = f"{lextag}-{ss_tag}"
+                    if ss2_tag != "@@<NO_SS2>@@":
+                        lextag = f"{lextag}|{ss2_tag}"
+                lextags.append(lextag)
+            all_lextags.append(lextags)
+        output_dict["lextags"] = all_lextags
         return output_dict
 
     @overrides

--- a/streusle_tagger/predictors/streusle_tagger.py
+++ b/streusle_tagger/predictors/streusle_tagger.py
@@ -12,9 +12,11 @@ class StreusleTaggerPredictor(Predictor):
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         """
-        Expects JSON that looks like ``{"tokens": "[...]", "upos_tags": "[...]"}``.
+        Expects JSON that looks like ``{"tokens": "[...]", "upos_tags": "[...]", "lemmas": "[...]"}``.
         """
         tokens = json_dict["tokens"]
         upos_tags = json_dict.get("upos_tags", None)
+        lemmas = json_dict.get("lemmas", None)
         return self._dataset_reader.text_to_instance(tokens=tokens,
-                                                     upos_tags=upos_tags)
+                                                     upos_tags=upos_tags,
+                                                     lemmas=lemmas)

--- a/tests/dataset_readers/streusle_test.py
+++ b/tests/dataset_readers/streusle_test.py
@@ -21,10 +21,14 @@ class TestStreusleDatasetReader():
                 'Have', 'a', 'real', 'mechanic', 'check', 'before', 'you', 'buy', '!!!!']
         assert fields["metadata"]["upos_tags"] == [
                 'VERB', 'DET', 'ADJ', 'NOUN', 'VERB', 'SCONJ', 'PRON', 'VERB', 'PUNCT']
-        assert fields["tags"].labels == ["B-V-v.social", "o-DET", "o-ADJ",
-                                         "o-N-n.PERSON", "I~-V-v.cognition",
-                                         "O-P-p.Time", "O-PRON", "O-V-v.possession",
-                                         "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['B-V', 'o-DET', 'o-ADJ', 'o-N', 'I~-V', 'O-P',
+                                                    'O-PRON', 'O-V', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ["v.social", "@@<NO_SS>@@", "@@<NO_SS>@@", "n.PERSON", "v.cognition",
+                                            "p.Time", "@@<NO_SS>@@", "v.possession", "@@<NO_SS>@@"]
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@"]
 
         instance = instances[1]
         fields = instance.fields
@@ -32,9 +36,12 @@ class TestStreusleDatasetReader():
                 "Very", "good", "with", "my", "5", "year", "old", "daughter", "."]
         assert fields["metadata"]["upos_tags"] == [
                 'ADV', 'ADJ', 'ADP', 'PRON', 'NUM', 'NOUN', 'ADJ', 'NOUN', 'PUNCT']
-        assert fields["tags"].labels == ["O-ADV", "O-ADJ", "O-P-??",
-                                         "O-PRON.POSS-p.SocialRel|p.Gestalt", "O-NUM",
-                                         "B-N-n.PERSON", "I_", "O-N-n.PERSON", "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['O-ADV', 'O-ADJ', 'O-P', 'O-PRON.POSS', 'O-NUM', 'B-N',
+                                                    'I_', 'O-N', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ["@@<NO_SS>@@", "@@<NO_SS>@@", "??", "p.SocialRel", "@@<NO_SS>@@",
+                                            "n.PERSON", "@@<NO_SS>@@", "n.PERSON", "@@<NO_SS>@@"]
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "p.Gestalt",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@"]
 
         instance = instances[2]
         fields = instance.fields
@@ -46,13 +53,19 @@ class TestStreusleDatasetReader():
                 'SCONJ', 'VERB', 'DET', 'NOUN', 'PRON', 'ADJ', 'NOUN', 'NOUN', 'VERB',
                 'DET', 'NOUN', 'AUX', 'PART', 'AUX', 'VERB', 'SCONJ', 'PRON', 'AUX',
                 'AUX', 'AUX', 'PUNCT']
-        assert fields["tags"].labels == ["O-P-p.Time", "O-V-v.social", "O-DET",
-                                         "O-N-n.GROUP", "O-PRON.POSS-p.OrgRole|p.Gestalt",
-                                         "O-ADJ", "B-N-n.ACT", "I_", "O-V-v.cognition",
-                                         "O-DET", "O-N-n.ARTIFACT", "O-AUX", "O-ADV",
-                                         "O-AUX", "O-V-v.change",
-                                         "O-P-p.ComparisonRef", "O-PRON", "O-AUX",
-                                         "O-AUX", "O-AUX", "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['O-P', 'O-V', 'O-DET', 'O-N', 'O-PRON.POSS', 'O-ADJ', 'B-N',
+                                                    'I_', 'O-V', 'O-DET', 'O-N', 'O-AUX', 'O-ADV',
+                                                    'O-AUX', 'O-V', 'O-P', 'O-PRON', 'O-AUX', 'O-AUX', 'O-AUX', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ['p.Time', 'v.social', '@@<NO_SS>@@', 'n.GROUP', 'p.OrgRole',
+                                            '@@<NO_SS>@@', 'n.ACT', '@@<NO_SS>@@', 'v.cognition', '@@<NO_SS>@@',
+                                            'n.ARTIFACT', '@@<NO_SS>@@', '@@<NO_SS>@@', '@@<NO_SS>@@', 'v.change',
+                                            'p.ComparisonRef', '@@<NO_SS>@@', '@@<NO_SS>@@', '@@<NO_SS>@@',
+                                            '@@<NO_SS>@@', '@@<NO_SS>@@']
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", '@@<NO_SS2>@@', "@@<NO_SS2>@@", 'p.Gestalt',
+                                             '@@<NO_SS2>@@', "@@<NO_SS2>@@", '@@<NO_SS2>@@', "@@<NO_SS2>@@", '@@<NO_SS2>@@',
+                                             "@@<NO_SS2>@@", '@@<NO_SS2>@@', '@@<NO_SS2>@@', '@@<NO_SS2>@@', "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", '@@<NO_SS2>@@', '@@<NO_SS2>@@', '@@<NO_SS2>@@',
+                                             '@@<NO_SS2>@@', '@@<NO_SS2>@@']
 
     @pytest.mark.parametrize('lazy', (True, False))
     def test_read_from_file_predicted_upos(self, lazy):
@@ -69,10 +82,14 @@ class TestStreusleDatasetReader():
                 'Have', 'a', 'real', 'mechanic', 'check', 'before', 'you', 'buy', '!!!!']
         assert fields["metadata"]["upos_tags"] == [
                 'VERB', 'DET', 'ADJ', 'ADJ', 'NOUN', 'SCONJ', 'PRON', 'VERB', 'PUNCT']
-        assert fields["tags"].labels == ["B-V-v.social", "o-DET", "o-ADJ",
-                                         "o-N-n.PERSON", "I~-V-v.cognition",
-                                         "O-P-p.Time", "O-PRON", "O-V-v.possession",
-                                         "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['B-V', 'o-DET', 'o-ADJ', 'o-N', 'I~-V', 'O-P',
+                                                    'O-PRON', 'O-V', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ["v.social", "@@<NO_SS>@@", "@@<NO_SS>@@", "n.PERSON", "v.cognition",
+                                            "p.Time", "@@<NO_SS>@@", "v.possession", "@@<NO_SS>@@"]
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@"]
 
         instance = instances[1]
         fields = instance.fields
@@ -80,9 +97,12 @@ class TestStreusleDatasetReader():
                 "Very", "good", "with", "my", "5", "year", "old", "daughter", "."]
         assert fields["metadata"]["upos_tags"] == [
                 'ADV', 'ADJ', 'ADP', 'PRON', 'NUM', 'NOUN', 'ADJ', 'NOUN', 'PUNCT']
-        assert fields["tags"].labels == ["O-ADV", "O-ADJ", "O-P-??",
-                                         "O-PRON.POSS-p.SocialRel|p.Gestalt", "O-NUM",
-                                         "B-N-n.PERSON", "I_", "O-N-n.PERSON", "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['O-ADV', 'O-ADJ', 'O-P', 'O-PRON.POSS', 'O-NUM', 'B-N',
+                                                    'I_', 'O-N', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ["@@<NO_SS>@@", "@@<NO_SS>@@", "??", "p.SocialRel", "@@<NO_SS>@@",
+                                            "n.PERSON", "@@<NO_SS>@@", "n.PERSON", "@@<NO_SS>@@"]
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "p.Gestalt",
+                                             "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@", "@@<NO_SS2>@@"]
 
         instance = instances[2]
         fields = instance.fields
@@ -94,10 +114,16 @@ class TestStreusleDatasetReader():
             'SCONJ', 'VERB', 'DET', 'NOUN', 'PRON', 'ADJ', 'NOUN', 'NOUN', 'VERB',
             'DET', 'NOUN', 'AUX', 'PART', 'AUX', 'VERB', 'SCONJ', 'PRON', 'AUX',
             'AUX', 'AUX', 'PUNCT']
-        assert fields["tags"].labels == ["O-P-p.Time", "O-V-v.social", "O-DET",
-                                         "O-N-n.GROUP", "O-PRON.POSS-p.OrgRole|p.Gestalt",
-                                         "O-ADJ", "B-N-n.ACT", "I_", "O-V-v.cognition",
-                                         "O-DET", "O-N-n.ARTIFACT", "O-AUX", "O-ADV",
-                                         "O-AUX", "O-V-v.change",
-                                         "O-P-p.ComparisonRef", "O-PRON", "O-AUX",
-                                         "O-AUX", "O-AUX", "O-PUNCT"]
+        assert fields["mwe_lexcat_tags"].labels == ['O-P', 'O-V', 'O-DET', 'O-N', 'O-PRON.POSS', 'O-ADJ', 'B-N',
+                                                    'I_', 'O-V', 'O-DET', 'O-N', 'O-AUX', 'O-ADV',
+                                                    'O-AUX', 'O-V', 'O-P', 'O-PRON', 'O-AUX', 'O-AUX', 'O-AUX', 'O-PUNCT']
+        assert fields["ss_tags"].labels == ['p.Time', 'v.social', '@@<NO_SS>@@', 'n.GROUP', 'p.OrgRole',
+                                            '@@<NO_SS>@@', 'n.ACT', '@@<NO_SS>@@', 'v.cognition', '@@<NO_SS>@@',
+                                            'n.ARTIFACT', '@@<NO_SS>@@', '@@<NO_SS>@@', '@@<NO_SS>@@', 'v.change',
+                                            'p.ComparisonRef', '@@<NO_SS>@@', '@@<NO_SS>@@', '@@<NO_SS>@@',
+                                            '@@<NO_SS>@@', '@@<NO_SS>@@']
+        assert fields["ss2_tags"].labels == ["@@<NO_SS2>@@", "@@<NO_SS2>@@", '@@<NO_SS2>@@', "@@<NO_SS2>@@", 'p.Gestalt',
+                                             '@@<NO_SS2>@@', "@@<NO_SS2>@@", '@@<NO_SS2>@@', "@@<NO_SS2>@@", '@@<NO_SS2>@@',
+                                             "@@<NO_SS2>@@", '@@<NO_SS2>@@', '@@<NO_SS2>@@', '@@<NO_SS2>@@', "@@<NO_SS2>@@",
+                                             "@@<NO_SS2>@@", '@@<NO_SS2>@@', '@@<NO_SS2>@@', '@@<NO_SS2>@@',
+                                             '@@<NO_SS2>@@', '@@<NO_SS2>@@']

--- a/tests/models/streusle_tagger_test.py
+++ b/tests/models/streusle_tagger_test.py
@@ -28,7 +28,7 @@ class StreusleTaggerTest(ModelTestCase):
         training_tensors = self.dataset.as_tensor_dict()
         output_dict = self.model(**training_tensors)
         output_dict = self.model.decode(output_dict)
-        for tag_type in ['mwe_lexcat_tags', 'ss_tags', 'ss2_tags', 'lextags']:
+        for tag_type in ['mwe_lexcat_tags', 'ss_tags', 'ss2_tags', 'tags']:
             tags = output_dict[tag_type]
             assert len(tags) == 3
             assert len(tags[0]) == 9

--- a/tests/models/streusle_tagger_test.py
+++ b/tests/models/streusle_tagger_test.py
@@ -28,7 +28,7 @@ class StreusleTaggerTest(ModelTestCase):
         training_tensors = self.dataset.as_tensor_dict()
         output_dict = self.model(**training_tensors)
         output_dict = self.model.decode(output_dict)
-        for tag_type in ['mwe_lexcat_tags', 'ss_tags', 'ss2_tags']:
+        for tag_type in ['mwe_lexcat_tags', 'ss_tags', 'ss2_tags', 'lextags']:
             tags = output_dict[tag_type]
             assert len(tags) == 3
             assert len(tags[0]) == 9

--- a/tests/models/streusle_tagger_test.py
+++ b/tests/models/streusle_tagger_test.py
@@ -1,8 +1,7 @@
 # pylint: disable=invalid-name,protected-access
-from flaky import flaky
-
 from allennlp.common.testing import ModelTestCase
-
+from flaky import flaky
+import numpy
 
 class StreusleTaggerTest(ModelTestCase):
     def setUp(self):
@@ -28,8 +27,10 @@ class StreusleTaggerTest(ModelTestCase):
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
         output_dict = self.model(**training_tensors)
-        tags = output_dict['tags']
-        assert len(tags) == 3
-        assert len(tags[0]) == 9
-        assert len(tags[1]) == 9
-        assert len(tags[2]) == 21
+        output_dict = self.model.decode(output_dict)
+        for tag_type in ['mwe_lexcat_tags', 'ss_tags', 'ss2_tags']:
+            tags = output_dict[tag_type]
+            assert len(tags) == 3
+            assert len(tags[0]) == 9
+            assert len(tags[1]) == 9
+            assert len(tags[2]) == 21

--- a/tests/predictors/streusle_tagger_test.py
+++ b/tests/predictors/streusle_tagger_test.py
@@ -12,7 +12,7 @@ class TestStreusleTaggerPredictor(AllenNlpTestCase):
         archive = load_archive('fixtures/streusle_tagger/serialization/model.tar.gz')
         predictor = Predictor.from_archive(archive, 'streusle-tagger')
         result = predictor.predict_json(inputs)
-        for tag_type in ["mwe_lexcat_tags", "ss_tags", "ss2_tags"]:
+        for tag_type in ["mwe_lexcat_tags", "ss_tags", "ss2_tags", "lextags"]:
             tags_list = result.get(tag_type)
             for tag in tags_list:
                 assert isinstance(tag, str)

--- a/tests/predictors/streusle_tagger_test.py
+++ b/tests/predictors/streusle_tagger_test.py
@@ -12,7 +12,7 @@ class TestStreusleTaggerPredictor(AllenNlpTestCase):
         archive = load_archive('fixtures/streusle_tagger/serialization/model.tar.gz')
         predictor = Predictor.from_archive(archive, 'streusle-tagger')
         result = predictor.predict_json(inputs)
-        for tag_type in ["mwe_lexcat_tags", "ss_tags", "ss2_tags", "lextags"]:
+        for tag_type in ["mwe_lexcat_tags", "ss_tags", "ss2_tags", "tags"]:
             tags_list = result.get(tag_type)
             for tag in tags_list:
                 assert isinstance(tag, str)

--- a/tests/predictors/streusle_tagger_test.py
+++ b/tests/predictors/streusle_tagger_test.py
@@ -12,10 +12,11 @@ class TestStreusleTaggerPredictor(AllenNlpTestCase):
         archive = load_archive('fixtures/streusle_tagger/serialization/model.tar.gz')
         predictor = Predictor.from_archive(archive, 'streusle-tagger')
         result = predictor.predict_json(inputs)
-        tags_list = result.get("tags")
-        for tag in tags_list:
-            assert isinstance(tag, str)
-            assert tag != ""
+        for tag_type in ["mwe_lexcat_tags", "ss_tags", "ss2_tags"]:
+            tags_list = result.get(tag_type)
+            for tag in tags_list:
+                assert isinstance(tag, str)
+                assert tag != ""
 
     def test_batch_prediction(self):
         inputs = [{"tokens": ["This", "is", "a", "sample", "sentence", "."]},

--- a/training_config/streusle_bert_large_cased_all_constraints.jsonnet
+++ b/training_config/streusle_bert_large_cased_all_constraints.jsonnet
@@ -35,7 +35,7 @@
     "batch_size": 64
   },
   "trainer": {
-    "validation_metric": "+accuracy",
+    "validation_metric": "+combined_em_accuracy",
     "optimizer": {
         "type": "adam",
         "lr": 0.001

--- a/training_config/streusle_bert_large_cased_all_constraints_predicted.jsonnet
+++ b/training_config/streusle_bert_large_cased_all_constraints_predicted.jsonnet
@@ -37,7 +37,7 @@
     "batch_size": 64
   },
   "trainer": {
-    "validation_metric": "+accuracy",
+    "validation_metric": "+combined_em_accuracy",
     "optimizer": {
         "type": "adam",
         "lr": 0.001

--- a/training_config/streusle_bert_large_cased_no_constraints.jsonnet
+++ b/training_config/streusle_bert_large_cased_no_constraints.jsonnet
@@ -35,7 +35,7 @@
     "batch_size": 64
   },
   "trainer": {
-    "validation_metric": "+accuracy",
+    "validation_metric": "+combined_em_accuracy",
     "optimizer": {
         "type": "adam",
         "lr": 0.001

--- a/training_config/streusle_bert_large_cased_upos_constraints.jsonnet
+++ b/training_config/streusle_bert_large_cased_upos_constraints.jsonnet
@@ -35,7 +35,7 @@
     "batch_size": 64
   },
   "trainer": {
-    "validation_metric": "+accuracy",
+    "validation_metric": "+combined_em_accuracy",
     "optimizer": {
         "type": "adam",
         "lr": 0.001

--- a/training_config/streusle_bert_large_cased_upos_constraints_predicted.jsonnet
+++ b/training_config/streusle_bert_large_cased_upos_constraints_predicted.jsonnet
@@ -36,7 +36,7 @@
     "batch_size": 64
   },
   "trainer": {
-    "validation_metric": "+accuracy",
+    "validation_metric": "+combined_em_accuracy",
     "optimizer": {
         "type": "adam",
         "lr": 0.001


### PR DESCRIPTION
Previously, we were predicting entire lextags (e.g., `I~-V-v.cognition` at once. This PR restructures the model to have 3 independent heads:

(1) predicts a MWE-lexcat chunk (i.e., `I~-V` above)
(2) predicts the `ss` (i.e., `v.cognition` above)
(3) predicts the `ss2` (in this case, `@@<NO_SS2>`)

They all use the same shared representation (frozen BERT vectors, for now).